### PR TITLE
Suite2p example updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
     # OSX ----------------------------------------
     # Pre-installed python versions
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 2.7.17 on macOS 10.14"
+      name: "Python 2.7.17 on macOS 10.14 [no suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
@@ -71,7 +71,7 @@ jobs:
         - TRAVIS_PYTHON_VERSION="2.7.17"
         - USE_SUITE2P="false"
 
-    - name: "Python 2.7.17 [oldest, no sima] on macOS 10.14"
+    - name: "Python 2.7.17 on macOS 10.14 [oldest, no sima/suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
@@ -81,7 +81,7 @@ jobs:
         - USE_SIMA="false"
         - USE_SUITE2P="false"
 
-    - name: "Python 3.7.5 [no sima] on macOS 10.14"
+    - name: "Python 3.7.5 on macOS 10.14 [no sima/suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
@@ -92,7 +92,7 @@ jobs:
 
     # Python versions which need to be installed
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.5.9 [oldest, no sima] on macOS 10.14"
+      name: "Python 3.5.9 on macOS 10.14 [oldest, no sima/suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
@@ -100,25 +100,28 @@ jobs:
         - TRAVIS_PYTHON_VERSION="3.5.9"
         - USE_OLDEST_DEPS="true"
         - USE_SIMA="false"
+        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.5.9 on macOS 10.14"
+      name: "Python 3.5.9 on macOS 10.14 [no suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
       env:
         - TRAVIS_PYTHON_VERSION="3.5.9"
+        - USE_SUITE2P="false"
 
     - if: type = cron AND branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.6.10 on macOS 10.14"
+      name: "Python 3.6.10 on macOS 10.14 [no suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
       env:
         - TRAVIS_PYTHON_VERSION="3.6.10"
+        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.8.2 [no sima] on macOS 10.14"
+      name: "Python 3.8.2 on macOS 10.14 [no sima/suite2p]"
       os: osx
       osx_image: xcode11.13
       language: shell
@@ -128,6 +131,11 @@ jobs:
         - USE_SUITE2P="false"
 
     # Ubuntu -------------------------------------
+    # Jobs to run on Conda
+    - python: "3.6"
+      env:
+        - USE_CONDA="numpy"
+
     # All versions pre-installed
     - python: "3.8"
       env:
@@ -146,10 +154,16 @@ jobs:
     - python: "3.5"
       env:
         - USE_OLDEST_DEPS="true"
+        - USE_SUITE2P="false"
 
     - python: "3.5"
+      env:
+        - USE_SUITE2P="false"
 
-    - python: "3.6"
+    - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
+      python: "3.6"
+      env:
+        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       python: "3.7"

--- a/examples/Suite2p example.ipynb
+++ b/examples/Suite2p example.ipynb
@@ -4,27 +4,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Using FISSA with Suite2p\n",
+    "# Using FISSA with Suite2p\n",
+    "\n",
     "Suite2P is blind source separation toolbox for cell detection and signal extraction. \n",
     "\n",
-    "Here we illustrate how one can both apply Suite2p, and extract the necessary components to follow up their analysis with our neuropil removal.\n",
+    "Here we illustrate how to use Suite2p to detect cell locations, and then use FISSA to remove neuropil signals from the ROI signals.\n",
     "\n",
-    "For more information about the Suite2p toolbox see: \n",
+    "For more information about the Suite2p toolbox see: https://github.com/MouseLand/suite2p\n",
     "\n",
-    "https://github.com/MouseLand/suite2p\n",
-    "\n",
-    "Pachitariu, M., Stringer, C., Dipoppa, M., Schröder, S., Rossi, L. F., Dalgleish, H., ... & Harris, K. D. (2017). Suite2p: beyond 10,000 neurons with standard two-photon microscopy. Biorxiv.\n",
+    "Pachitariu, M., Stringer, C., Dipoppa, M., Schröder, S., Rossi, L. F., Dalgleish, H., Carandini, M. & Harris, K. D. (2017). Suite2p: beyond 10,000 neurons with standard two-photon microscopy. bioRxiv:[061507](https://www.biorxiv.org/content/10.1101/061507v2); doi:[10.1101/061507](https://doi.org/10.1101/061507).\n",
     "\n",
     "The Suite2P parts of this tutorial are based on their [Jupyter notebook example](https://github.com/MouseLand/suite2p/blob/master/jupyter/run_pipeline_tiffs_or_batch.ipynb).\n",
     "\n",
-    "Note that the below results are not representative of either Suite2P or FISSA performance, as it is just example data."
+    "Note that the below results are not representative of either Suite2P or FISSA performance, as we are using a very small example dataset."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Imports"
+    "## Imports"
    ]
   },
   {
@@ -42,14 +41,14 @@
     "import fissa\n",
     "\n",
     "# Suite2P\n",
-    "from suite2p import run_s2p"
+    "import suite2p.run_s2p"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run Suite2p"
+    "## Run Suite2p"
    ]
   },
   {
@@ -58,35 +57,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# set your options for running\n",
-    "ops = run_s2p.default_ops() # populates ops with the default options\n",
+    "# Set your options for running\n",
+    "ops = suite2p.run_s2p.default_ops()  # populates ops with the default options\n",
     "\n",
-    "# provide an h5 path in 'h5py' or a tiff path in 'data_path'\n",
+    "# Provide an h5 path in 'h5py' or a tiff path in 'data_path'\n",
     "# db overwrites any ops (allows for experiment specific settings)\n",
     "db = {\n",
-    "      'h5py': [], # a single h5 file path\n",
-    "      'h5py_key': 'data',\n",
-    "      'look_one_level_down': False, # whether to look in ALL subfolders when searching for tiffs\n",
-    "      'data_path': ['exampleData/20150529'], # a list of folders with tiffs \n",
-    "                                             # (or folder of folders with tiffs if look_one_level_down is True, or subfolders is not empty)\n",
-    "      'save_path0': './',# save path                                      \n",
-    "      'subfolders': [], # choose subfolders of 'data_path' to look in (optional)\n",
-    "      'fast_disk': './', # string which specifies where the binary file will be stored (should be an SSD)\n",
-    "      'reg_tif': True, # save the motion corrected tiffs\n",
-    "      'tau': 0.7, # timescale of gcamp6f\n",
-    "      'fs': 1, # sampling rate\n",
-    "      'spatial_scale': 4\n",
-    "    }\n",
+    "    'h5py': [],  # a single h5 file path\n",
+    "    'h5py_key': 'data',\n",
+    "    'look_one_level_down': False,  # whether to look in ALL subfolders when searching for tiffs\n",
+    "    'data_path': ['exampleData/20150529'],  # a list of folders with tiffs \n",
+    "                                            # (or folder of folders with tiffs if look_one_level_down is True,\n",
+    "                                            # or subfolders is not empty)\n",
+    "    'save_path0': './',  # save path                                      \n",
+    "    'subfolders': [],  # choose subfolders of 'data_path' to look in (optional)\n",
+    "    'fast_disk': './',  # string which specifies where the binary file will be stored (should be an SSD)\n",
+    "    'reg_tif': True,  # save the motion corrected tiffs\n",
+    "    'tau': 0.7,  # timescale of gcamp6f\n",
+    "    'fs': 1,  # sampling rate\n",
+    "    'spatial_scale': 4\n",
+    "}\n",
     "\n",
-    "# run one experiment\n",
-    "opsEnd=run_s2p.run_s2p(ops=ops,db=db)"
+    "# Run one experiment\n",
+    "opsEnd = suite2p.run_s2p.run_s2p(ops=ops, db=db)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load the relevant data from the analysis"
+    "## Load the relevant data from the analysis"
    ]
   },
   {
@@ -95,37 +95,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# extract the motion corrected tiffs (make sure that the reg_tif option is set to true, see above)\n",
+    "# Extract the motion corrected tiffs (make sure that the reg_tif option is set to true, see above)\n",
     "images = './suite2p/plane0/reg_tif'\n",
     "\n",
-    "# load the detected regions of interest\n",
-    "stat = np.load('./suite2p/plane0/stat.npy', allow_pickle=True) # cell stats\n",
-    "ops = np.load('./suite2p/plane0/ops.npy', allow_pickle=True).item() # \n",
+    "# Load the detected regions of interest\n",
+    "stat = np.load('./suite2p/plane0/stat.npy', allow_pickle=True)  # cell stats\n",
+    "ops = np.load('./suite2p/plane0/ops.npy', allow_pickle=True).item()\n",
     "iscell = np.load('./suite2p/plane0/iscell.npy', allow_pickle=True)[:, 0] \n",
     "\n",
-    "# get image size\n",
+    "# Get image size\n",
     "Lx = ops['Lx']\n",
     "Ly = ops['Ly']\n",
     "\n",
-    "# get the actual cell ids\n",
+    "# Get the cell ids\n",
     "ncells = len(stat)\n",
-    "cell_ids = np.arange(0, ncells) # this gives each cell a number. Edna: the ID start from 0 and so on.\n",
-    "cell_ids = cell_ids[iscell==1] # only take the ones that are actually cells.\n",
+    "cell_ids = np.arange(ncells)  # assign each cell an ID, starting from 0.\n",
+    "cell_ids = cell_ids[iscell==1]  # only take the ROIs that are actually cells.\n",
     "num_rois = len(cell_ids) \n",
     "\n",
-    "# generate actual ROI masks in a format usable FISSA (in this case, a list of masks)\n",
-    "ROIS = [np.zeros((Ly, Lx), dtype=bool) for n in range(num_rois)]\n",
-    "for i, n in enumerate(cell_ids): # with enumerate i is the position in cell_ids, and n is the actual cell number\n",
+    "# Generate ROI masks in a format usable by FISSA (in this case, a list of masks)\n",
+    "ROIs = [np.zeros((Ly, Lx), dtype=bool) for n in range(num_rois)]\n",
+    "for i, n in enumerate(cell_ids):\n",
+    "    # i is the position in cell_ids, and n is the actual cell number\n",
     "    ypix = stat[n]['ypix'][~stat[n]['overlap']]\n",
     "    xpix = stat[n]['xpix'][~stat[n]['overlap']]\n",
-    "    ROIS[i][ypix,xpix] = 1"
+    "    ROIs[i][ypix, xpix] = 1"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run FISSA with the defined ROIs and data"
+    "## Run FISSA with the defined ROIs and data"
    ]
   },
   {
@@ -135,8 +136,15 @@
    "outputs": [],
    "source": [
     "output_folder = 'fissa_suite2p_example'\n",
-    "exp = fissa.Experiment(images, [ROIS[:ncells]], output_folder)\n",
+    "exp = fissa.Experiment(images, [ROIs[:ncells]], output_folder)\n",
     "exp.separate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot the resulting ROI signals"
    ]
   },
   {
@@ -148,38 +156,50 @@
    "outputs": [],
    "source": [
     "%%opts Curve {+axiswise}\n",
-    "colors = hv.core.options.Cycle.default_cycles['default_colors']\n",
-    "Ncolors = len(colors)\n",
     "\n",
-    "# function for a single cell region plot\n",
-    "def plot_cell_regions(cell):\n",
+    "\n",
+    "def plot_cell_regions(cell, plot_neuropil=False):\n",
+    "    '''\n",
+    "    Plot a single cell region, with holoviews.\n",
+    "    '''\n",
     "    out = hv.Overlay()\n",
-    "    numReg = len(exp.roi_polys[cell][0]) # Number of regions\n",
-    "    for i in range(1): # set this to range(numReg) to also get the neuropil regions\n",
-    "        numParts = len(exp.roi_polys[cell][0][i]) # number of parts in the current region\n",
+    "    if plot_neuropil:\n",
+    "        # Plot the neuropil as well as the ROI\n",
+    "        numReg = len(exp.roi_polys[cell][0])\n",
+    "    else:\n",
+    "        # Just plot the ROI, not the neuropil\n",
+    "        numReg = 1\n",
+    "    for i in range(numReg):\n",
+    "        # number of parts in the current region\n",
+    "        numParts = len(exp.roi_polys[cell][0][i])\n",
     "        for j in range(numParts):\n",
     "            x = exp.roi_polys[cell][0][i][j][:, 1]\n",
     "            y = exp.roi_polys[cell][0][i][j][:, 0]\n",
-    "            out *= hv.Curve(zip(x,y)).opts(color='w')\n",
+    "            out *= hv.Curve(zip(x, y)).opts(color='w')\n",
     "    return out\n",
     "\n",
-    "# get plots for all detected regions\n",
+    "\n",
+    "# Get plots for all detected regions\n",
     "region_plots = {i : plot_cell_regions(i) for i in range(exp.nCell)}\n",
     "\n",
-    "# get plots for raw extracts and neuropil removed\n",
-    "traces_plots = {i : hv.Curve(exp.raw[i][1][0,:], label='Suite2p')*hv.Curve(exp.result[i][1][0,:], label='FISSA') for i in range(exp.nCell)}\n",
+    "# Get plots for raw extracts and neuropil removed\n",
+    "traces_plots = {\n",
+    "    i: hv.Curve(exp.raw[i][1][0,:], label='Suite2p') * hv.Curve(exp.result[i][1][0,:], label='FISSA')\n",
+    "    for i in range(exp.nCell)\n",
+    "}\n",
     "\n",
-    "# get average image\n",
+    "# Get average image\n",
     "avg_img = hv.Raster(opsEnd[0]['meanImg'])\n",
     "\n",
-    "avg_img*hv.HoloMap(region_plots,kdims=['Cell'])+hv.HoloMap(traces_plots,kdims=['Cell'])"
+    "# Render holoviews\n",
+    "avg_img * hv.HoloMap(region_plots, kdims=['Cell']) + hv.HoloMap(traces_plots, kdims=['Cell'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that with the above settings for Suite2P it seems to have detected more small local axon signals, instead of cells. This can possibly be improved with manual curation and Suite2P setting changes, but as noted above these results should be seen as indicative for either Suite2P or FISSA due to the small data-set. Also note that the above Suite2P traces are done without Suite2P's own neuropil removal algorithm."
+    "Note that with the above settings for Suite2P it seems to have detected more small local axon signals, instead of cells. This can possibly be improved with manual curation and Suite2P setting changes, but as noted above these results should not be seen as indicative for either Suite2P or FISSA due to the small dataset size. Also note that the above Suite2P traces are done without Suite2P's own neuropil removal algorithm."
    ]
   }
  ],


### PR DESCRIPTION
- Update notebook, fixing PEP8 and lint errors, and improving some comments. Link to suite2p paper, and add an important missing word `not` in the final markdown block `but as noted above these results should [not] be seen as indicative for either Suite2P or FISSA`.
- Fix travis jobs. Now run one conda job for suite2p, and don't test suite2p notebook otherwise.